### PR TITLE
Update Jaeger to V2

### DIFF
--- a/kubernetes/jaeger.yaml
+++ b/kubernetes/jaeger.yaml
@@ -21,8 +21,8 @@ spec:
         app: jaeger
     spec:
       containers:
-      - image: jaegertracing/all-in-one:1.57
-        name: all-in-one
+      - image: jaegertracing/jaeger:2.1.0
+        name: jaeger-v2
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This pull request includes an update to the Jaeger container image in the `kubernetes/jaeger.yaml` file. The change updates the image version and the container name for better clarity and consistency.

* [`kubernetes/jaeger.yaml`](diffhunk://#diff-ca6abbd6359414d93a6f29924bd34aaa186a9c7c5c65b90a2b6dfd048ea98ed0L24-R25): Updated the Jaeger container image from `jaegertracing/all-in-one:1.57` to `jaegertracing/jaeger:2.1.0` ( [Release Notes](https://github.com/jaegertracing/jaeger/releases/tag/v1.64.0) ) and changed the container name from `all-in-one` to `jaeger-v2`.