### PR TITLE
Fix inventory image build

### DIFF
--- a/inventory/Dockerfile
+++ b/inventory/Dockerfile
@@ -23,7 +23,7 @@ RUN pip install poetry
 
 # Install project dependencies
 RUN poetry config virtualenvs.create false \
-    && poetry install --no-dev
+    && poetry install
 
 # Stage 2: Runtime Stage
 FROM python:3.11-slim

--- a/inventory/pyproject.toml
+++ b/inventory/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Eden Federman <eden@keyval.dev>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
This PR updates the Python poetry dependency management and install command to allow the image build to succeed.

Error when building on current head of `main`:

```
 => ERROR [builder 6/6] RUN poetry config virtualenvs.create false     && poetry install --no-dev                                                                                1.6s
------                                                                                                                                                                                
 > [builder 6/6] RUN poetry config virtualenvs.create false     && poetry install --no-dev:                                                                                           
1.422 Skipping virtualenv creation, as specified in config file.
1.536 
1.536 The option "--no-dev" does not exist
```