### PR TITLE
Remove securityContext from frontend deployment

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -54,8 +54,6 @@ spec:
       - name: frontend
         image: keyval/odigos-demo-frontend:v0.1.14
         imagePullPolicy: Always
-        securityContext:
-          runAsUser: 1000
         env:
         - name: INVENTORY_SERVICE_HOST
           value: inventory:8080


### PR DESCRIPTION
This causes an error when running in OpenShift that prevents the frontend service from deploying:

```
Warning  FailedCreate  33s (x16 over 115s)  replicaset-controller  Error creating: pods "frontend-c99dd5fdd-" is forbidden: unable to validate against any security context constraint: [provider "anyuid": Forbidden: not usable by user or serviceaccount, provider restricted-v2: .containers[0].runAsUser: Invalid value: 1000: must be in the ranges: [1001020000, 1001029999], provider "restricted": Forbidden: not usable by user or serviceaccount, provider "nonroot-v2": Forbidden: not usable by user or serviceaccount, provider "nonroot": Forbidden: not usable by user or serviceaccount, provider "pcap-dedicated-admins": Forbidden: not usable by user or serviceaccount, provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount, provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount, provider "hostnetwork-v2": Forbidden: not usable by user or serviceaccount, provider "hostnetwork": Forbidden: not usable by user or serviceaccount, provider "hostaccess": Forbidden: not usable by user or serviceaccount, provider "splunkforwarder": Forbidden: not usable by user or serviceaccount, provider "node-exporter": Forbidden: not usable by user or serviceaccount, provider "privileged": Forbidden: not usable by user or serviceaccount]
```