### PR TITLE
currency: Add required packages for composer

### DIFF
--- a/currency/Dockerfile
+++ b/currency/Dockerfile
@@ -2,6 +2,12 @@ FROM php:8.2-cli
 WORKDIR /app
 COPY . /app
 
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    zip \
+    unzip
+
 RUN curl -sS https://getcomposer.org/installer | php && \
   mv composer.phar /usr/local/bin/composer && \
   composer install


### PR DESCRIPTION
Trying to build locally I got the following error:

```
 => ERROR [4/4] RUN curl -sS https://getcomposer.org/installer | php &&   mv composer.phar /usr/local/bin/composer &&   composer install                                                                                 1.7s
------                                                                                                                                                                                                                        
 > [4/4] RUN curl -sS https://getcomposer.org/installer | php &&   mv composer.phar /usr/local/bin/composer &&   composer install:                                                                                            
0.495 All settings correct for using Composer                                                                                                                                                                                 
0.499 Downloading...                                                                                                                                                                                                          
1.627 
1.627 Composer (version 2.8.8) successfully installed to: /app/composer.phar
1.627 Use it: php composer.phar
1.627 
1.701 Installing dependencies from lock file (including require-dev)
1.702 Verifying lock file contents can be installed on current platform.
1.714 Package operations: 13 installs, 0 updates, 0 removals
1.716     Failed to download psr/log from dist: The zip extension and unzip/7z commands are both missing, skipping.
1.716 The php.ini used by your command-line PHP is: /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini
1.716     Now trying to download from source
1.717 
1.718 In GitDownloader.php line 82:
1.718                                                             
1.718   git was not found in your PATH, skipping source download  
1.718                                                             
1.718 
1.718 install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--download-only] [--dev] [--no-suggest] [--no-dev] [--no-autoloader] [--no-progress] [--no-install] [--audit] [--audit-format AUDIT-FORMAT] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>...]
1.718 
------
Dockerfile:5
--------------------
   4 |     
   5 | >>> RUN curl -sS https://getcomposer.org/installer | php && \
   6 | >>>   mv composer.phar /usr/local/bin/composer && \
   7 | >>>   composer install
   8 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c curl -sS https://getcomposer.org/installer | php &&   mv composer.phar /usr/local/bin/composer &&   composer install" did not complete successfully: exit code: 1
make: *** [build-images] Error 1
```