### PR TITLE
ci: publish images also to github registry to use later in ci tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,20 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and Push Docker Image for ${{ matrix.service }}
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: us-central1-docker.pkg.dev/odigos-cloud/components/odigos-demo-${{ matrix.service }}:${{ env.TAG }}
+          tags: |
+            us-central1-docker.pkg.dev/odigos-cloud/components/odigos-demo-${{ matrix.service }}:${{ env.TAG }}
+            ghcr.io/${{ github.repository_owner }}/odigos-demo-${{ matrix.service }}:${{ env.TAG }}
           platforms: linux/amd64,linux/arm64
           file: ${{ matrix.service }}/Dockerfile
           context: ${{ matrix.service }}


### PR DESCRIPTION
I want to experiment with publishing simple-demo and then consuming the images from ghcr in odigos repo for e2e tests.

These tests are currently pulling from `registry.odigos.io` which is inefficient, costly, and noisey neighbour for odigos real users.

It's hard to know if it will work, so let's hope