### PR TITLE
ci: pin php version and verify docker build in prs

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -1,0 +1,48 @@
+name: Verify Docker Builds
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  verify-docker-builds:
+    strategy:
+      matrix:
+        include:
+          - service: coupon
+          - service: currency
+          - service: frontend
+          - service: geolocation
+          - service: inventory
+          - service: membership
+          - service: pricing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Build Docker Image for ${{ matrix.service }}
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+          load: true
+          platforms: linux/amd64
+          file: ${{ matrix.service }}/Dockerfile
+          context: ${{ matrix.service }}
+          tags: odigos-demo-${{ matrix.service }}:pr-test
+
+      - name: Verify image was created
+        run: |
+          docker images | grep odigos-demo-${{ matrix.service }}
+          echo "✅ Successfully built ${{ matrix.service }} Docker image" 

--- a/currency/Dockerfile
+++ b/currency/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm
+FROM php:8.2.28-fpm
 WORKDIR /app
 COPY . /app
 

--- a/currency/Dockerfile
+++ b/currency/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.28-fpm
+FROM php:8.2.29-fpm
 WORKDIR /app
 COPY . /app
 


### PR DESCRIPTION
php version is set with `8.2` but then verified in tests to be `8.2.28`.

this PR bumps it to `8.2.29` which is latest at time of writing, and pin it to exact version so it doesn't fail in e2e tests when php release `8.2.30`