### PR TITLE
Update access_token_lifetime in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           token_format: 'access_token'
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          access_token_lifetime: 1200s
+          access_token_lifetime: 1800s
 
       - name: Login to Artifact Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
Release workflow can fail with `ERROR: failed to solve: failed to fetch oauth token: unexpected status from GET request to https://us-central1-docker.pkg.dev/v2/token?scope=repository%3Aodigos-cloud%2Fcomponents%2Fodigos-demo-geolocation%3Apull%2Cpush&service=us-central1-docker.pkg.dev: 401 Unauthorized`

Currently the access token lifetime is set to 20 minutes, but the geolocation build can take longer than that, see sample run below which took 21 minutes

This updates the lifetime to 30 minutes

Example: https://github.com/odigos-io/simple-demo/actions/runs/15661916012/job/44121366799#step:8:2730