### PR TITLE
feat: add promethues to simple demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ Create a Kubernetes cluster, and apply the following manifests:
 
 - simple demo application - `kubectl apply -f https://raw.githubusercontent.com/odigos-io/simple-demo/main/kubernetes/deployment.yaml`
 - jaeger - `kubectl apply -f https://raw.githubusercontent.com/odigos-io/simple-demo/main/kubernetes/jaeger.yaml`
+- promethues - `kubectl apply -f https://raw.githubusercontent.com/odigos-io/simple-demo/main/kubernetes/promethues.yaml`
 
 After you installed odigos:
 
 - instrument demo apps with odigos - `kubectl apply -f https://raw.githubusercontent.com/odigos-io/simple-demo/main/kubernetes/instrument-all.yaml`
 - add jaeger destination to odigos - `kubectl apply -f https://raw.githubusercontent.com/odigos-io/simple-demo/main/kubernetes/jaeger-dest.yaml`
+- add promethues destination to odigos - `kubectl apply -f https://raw.githubusercontent.com/odigos-io/simple-demo/main/kubernetes/promethues-dest.yaml`
 
 Do it all in one command:
 

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
   - jaeger.yaml
   - instrument-all.yaml
   - jaeger-dest.yaml
+  - promethues.yaml
+  - promethues-dest.yaml

--- a/kubernetes/promethues-dest.yaml
+++ b/kubernetes/promethues-dest.yaml
@@ -1,0 +1,17 @@
+apiVersion: odigos.io/v1alpha1
+kind: Destination
+metadata:
+  name: promethues-rw
+  namespace: odigos-system
+spec:
+  data:
+    PROMETHEUS_REMOTEWRITE_URL: http://prometheus.promethues:9090/api/v1/write
+  destinationName: "promethues remote write"
+  signals:
+  - METRICS
+  sourceSelector:
+    dataStreams:
+    - default
+  type: prometheus
+  metricsSettings:
+    spanMetricsEnabled: true

--- a/kubernetes/promethues.yaml
+++ b/kubernetes/promethues.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: promethues
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: promethues
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 1m
+      evaluation_interval: 1m
+    # No rules, no alertmanagers, no scrapes
+    rule_files: []
+    scrape_configs: []
+    otlp:
+      promote_resource_attributes:
+        - service.name
+        - service.instance.id
+        - k8s.pod.name
+        - k8s.namespace.name
+        - k8s.deployment.name
+        - k8s.container.name
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: promethues
+  labels:
+    app.kubernetes.io/name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v3.7.3
+        args:
+          - "--config.file=/etc/prometheus/prometheus.yml"
+          - "--web.enable-otlp-receiver"
+          - "--web.external-url=http://prometheus.promethues:9090"
+          - "--web.route-prefix=/"
+          - "--enable-feature=remote-write-receiver"
+          - "--storage.tsdb.path=/tmp/prom-tsdb"
+          - "--storage.tsdb.retention.time=24h"
+          - "--storage.tsdb.retention.size=2GB"
+          - "--web.enable-lifecycle"
+          - "--web.enable-remote-write-receiver"
+        ports:
+        - name: http
+          containerPort: 9090
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: http
+          initialDelaySeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: http
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65534
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+      volumes:
+      - name: config
+        configMap:
+          name: prometheus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: promethues
+  labels:
+    app.kubernetes.io/name: prometheus
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 9090
+    targetPort: http
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: prometheus


### PR DESCRIPTION
similar to jaeger - add an option to apply a simple promethues deployment + destination.
this will allow to showcase / experiment / develop metrics related features 

since it's only adding manifests - there is no implication to existing users that consume the `deployment.yaml` / jaeger.yaml` files. if someone uses the kustomize manifest, they will now get promethues as well which is nice

emergency-ticket id: EMR-523
