### PR TITLE
Fix goof

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,6 @@ jobs:
         run: |
           docker buildx imagetools create --tag "ghcr.io/${{ github.repository }}/odigos-demo-${{ matrix.service }}:${{ env.TAG }}" \
             "${{ env.GCP_REGISTRY }}/odigos-demo-${{ matrix.service }}:${{ env.TAG }}"
-          docker buildx imagetools push "ghcr.io/${{ github.repository }}/odigos-demo-${{ matrix.service }}:${{ env.TAG }}"
 
       - name: Upload Linux packages to Artifact Registry
         uses: odigos-io/ci-core/upload-linux-packages@v1.0.5


### PR DESCRIPTION
docker buildx imagetools create already pushes the image to ghcr.io

emergency-ticket id: EMR-1101
