### PR TITLE
CORE-680: Update manifests to v0.1.36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ dev-deploy: $(addprefix dev-deploy-,$(APPS))
 # Build and package (delegate to each app's Makefile)
 ##################################################
 
-VERSION ?= v0.1.31
+VERSION ?= v0.1.36
 
 # build-all and build-all-% must appear before build/build-% so BSD make (macOS) matches
 # build-all-coupon to build-all-% (stem coupon) rather than build-% (stem all-coupon).

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: load-generator
-              image: registry.odigos.io/odigos-demo-load-generator:v0.1.35
+              image: registry.odigos.io/odigos-demo-load-generator:v0.1.36
               imagePullPolicy: Always
               env:
                 - name: FRONTEND_SERVICE_HOST
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
         - name: coupon
-          image: registry.odigos.io/odigos-demo-coupon:v0.1.35
+          image: registry.odigos.io/odigos-demo-coupon:v0.1.36
           imagePullPolicy: Always
           env:
             - name: MEMBERSHIP_SERVICE_HOST
@@ -91,7 +91,7 @@ spec:
     spec:
       containers:
         - name: currency
-          image: registry.odigos.io/odigos-demo-currency:v0.1.35
+          image: registry.odigos.io/odigos-demo-currency:v0.1.36
           imagePullPolicy: Always
           env:
             - name: GEOLOCATION_SERVICE_HOST
@@ -160,7 +160,7 @@ spec:
     spec:
       containers:
         - name: frontend
-          image: registry.odigos.io/odigos-demo-frontend:v0.1.35
+          image: registry.odigos.io/odigos-demo-frontend:v0.1.36
           imagePullPolicy: Always
           env:
             - name: INVENTORY_SERVICE_HOST
@@ -211,7 +211,7 @@ spec:
     spec:
       containers:
         - name: shipping
-          image: registry.odigos.io/odigos-demo-shipping:v0.1.35
+          image: registry.odigos.io/odigos-demo-shipping:v0.1.36
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -251,7 +251,7 @@ spec:
     spec:
       containers:
         - name: geolocation
-          image: registry.odigos.io/odigos-demo-geolocation:v0.1.35
+          image: registry.odigos.io/odigos-demo-geolocation:v0.1.36
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
@@ -305,7 +305,7 @@ spec:
     spec:
       containers:
         - name: inventory
-          image: registry.odigos.io/odigos-demo-inventory:v0.1.35
+          image: registry.odigos.io/odigos-demo-inventory:v0.1.36
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -343,7 +343,7 @@ spec:
     spec:
       containers:
         - name: membership
-          image: registry.odigos.io/odigos-demo-membership:v0.1.35
+          image: registry.odigos.io/odigos-demo-membership:v0.1.36
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -384,7 +384,7 @@ spec:
     spec:
       containers:
         - name: pricing
-          image: registry.odigos.io/odigos-demo-pricing:v0.1.35
+          image: registry.odigos.io/odigos-demo-pricing:v0.1.36
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Following https://github.com/odigos-io/simple-demo/pull/67 and the release of v0.1.36 with the new c++ shipping service